### PR TITLE
avoid critical error when interpolated string is malformatted for sprintf

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -263,7 +263,19 @@ class Counterpart extends events.EventEmitter {
     return this._registry.normalizedKeys[separator][key];
   }
 
-  _interpolate = (entry, values) => (typeof entry !== 'string') ? entry : sprintf(entry, extend({}, this._registry.interpolations, values));
+  _interpolate = (entry, values) => {
+  	if (typeof entry !== 'string') {
+  		return entry;
+  	}
+  	let ret = "";
+  	try {
+		ret = sprintf(entry, extend({}, this._registry.interpolations, values));  		
+  	} catch(e) {
+  		console.log("counterpart: error. Malformatted string '" + entry + "'!");
+  		ret = entry;
+  	}
+  	return ret;
+  }
 
   _resolve = (locale, scope, object, subject, options={}) => {
     if (options.resolve === false) {


### PR DESCRIPTION
Now the console log echoes an error to developper: "counterpart: error because of malformatted string for interpolation" and gives the string, making it really easy for developper to fix the wrong string. In case of error, counterpart will simply print the string without the interpolations, giving the user a much better experience and avoiding to kill the app with a critical error.